### PR TITLE
Cleaning, aggregation, and filtering updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A module for creating reproducible partitions of the nuMoM2b data set based on configuration files.
 
 [![Documentation Status](https://readthedocs.org/projects/numom2b-preprocessing/badge/?version=latest)](https://doc.numom2b.org/en/latest/?badge=latest)
+[![LGTM Code Review](https://img.shields.io/lgtm/grade/python/github/hayesall/nuMoM2b_preprocessing?label=code%20quality&logo=lgtm)](https://lgtm.com/projects/g/hayesall/nuMoM2b_preprocessing/context:python)
 [![Build Status](https://travis-ci.com/hayesall/nuMoM2b_preprocessing.svg?branch=master)](https://travis-ci.com/hayesall/nuMoM2b_preprocessing)
 [![codecov](https://codecov.io/gh/hayesall/nuMoM2b_preprocessing/branch/master/graph/badge.svg)](https://codecov.io/gh/hayesall/nuMoM2b_preprocessing)
 

--- a/documentation/source/api/numom2b_preprocessing.get_config.rst
+++ b/documentation/source/api/numom2b_preprocessing.get_config.rst
@@ -1,6 +1,6 @@
-==============
+##############
 ``get_config``
-==============
+##############
 
 .. automodule:: numom2b_preprocessing.get_config
     :members:
@@ -8,7 +8,7 @@
     :show-inheritance:
 
 Available Options
------------------
+=================
 
 * ``"csv_path"``: Path to directory where all ``.csv`` files are located
 * ``"files"``: List of entries naming individual files
@@ -21,7 +21,7 @@ Available Options
   * ``"name"``: ``.csv`` file name (``csv_path`` will be appended to the beginning)
   * ``"variables"``: Names of columns to include from the target file
 
-* ``"groupings"``: List of objects describing how to aggregate columns
+* ``"aggregate_columns"``: List of objects describing how to aggregate columns
 
   * ``"operator"``: "mean", "last", or "count"
   * ``"columns"``: List of column names to apply aggregation operator to. *These columns are dropped after aggregating*
@@ -30,13 +30,13 @@ Available Options
   If none is specified, the column is named according to which columns were aggregated and what operator was used
 
 Example Usage
--------------
+=============
 
 >>> from numom2b_preprocessing import get_config
 >>> _params = get_config.parameters(config="phi_config.json")
 
 Example File
-------------
+============
 
 .. code-block:: json
 
@@ -62,5 +62,5 @@ Example File
           ]
         }
       ],
-      "groupings": []
+      "aggregate_columns": []
     }

--- a/documentation/source/config_files/01.rst
+++ b/documentation/source/config_files/01.rst
@@ -33,5 +33,5 @@ file locations on your specific machine.
         ]
       }
     ],
-    "groupings": []
+    "aggregate_columns": []
   }

--- a/documentation/source/config_files/02.rst
+++ b/documentation/source/config_files/02.rst
@@ -34,7 +34,7 @@ file locations on your specific machine.
       "name": "Ancillary/Pregnancy_outcomes.csv",
       "variables": ["PublicID", "oDM"]
     },
-    "groupings": [
+    "aggregate_columns": [
       {
         "operator": "last",
         "columns": ["V1BA02a", "V1BA02b", "V1BA02c"],

--- a/documentation/source/first_config.rst
+++ b/documentation/source/first_config.rst
@@ -1,6 +1,6 @@
-===================
+###################
 Configuration Files
-===================
+###################
 
 Perhaps you want to know whether a woman's *weight during the first visit* might be
 informative for determining whether or not she develops gestational diabetes later
@@ -29,7 +29,7 @@ does not work yet, but shows us all the keys that we will need to work with.
         "csv_path": "../FullData/numom_data/",
         "target": {},
         "files": [],
-        "groupings": []
+        "aggregate_columns": []
     }
 
 Let's start with the ``"target"``. The target is the file that contains information
@@ -55,7 +55,7 @@ we want to include.
             "variables": ["PublicID", "oDM"]
         },
         "files": [],
-        "groupings": []
+        "aggregate_columns": []
     }
 
 Adding this to ``example_config.json`` is enough to produce a ``data.csv`` when we
@@ -94,7 +94,7 @@ to keep track of which record corresponds to which person.
                 "variables": ["PublicID", "V1BA01_KG", "V1BA01_LB"]
             }
         ],
-        "groupings": []
+        "aggregate_columns": []
     }
 
 .. code-block:: bash
@@ -109,8 +109,8 @@ to keep track of which record corresponds to which person.
     3.0,NaN,144
     2.0,76,NaN
 
-Now that we have the variables we want, we can use the ``"groupings"`` section to convert
-them to common units. Operations defined in the ``"groupings"`` section are executed from
+Now that we have the variables we want, we can use the ``"aggregate_columns"`` section to convert
+them to common units. Operations defined in the ``"aggregate_columns"`` section are executed from
 top to bottom.
 
 First, we multiply the ``"V1BA01_KG"`` variable by 2.20462, which converts the measurements to
@@ -135,7 +135,7 @@ This can be written as follows:
           "variables": ["PublicID", "V1BA01_KG", "V1BA01_LB"]
         }
       ],
-      "groupings": [
+      "aggregate_columns": [
         {
           "operator": "multiply_constant",
           "columns": ["V1BA01_KG"],

--- a/numom2b_preprocessing/_meta.py
+++ b/numom2b_preprocessing/_meta.py
@@ -4,7 +4,7 @@ __author__ = "Alexander L. Hayes (@hayesall)"
 __copyright__ = "Copyright © 2019 Alexander L. Hayes"
 __license__ = "MIT"
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __status__ = "Alpha"
 __maintainer__ = "Alexander L. Hayes (@hayesall)"
 __email__ = "hayesall@iu.edu"

--- a/numom2b_preprocessing/aggregate_columns.py
+++ b/numom2b_preprocessing/aggregate_columns.py
@@ -27,13 +27,13 @@ class ColumnAggregator:
         :param operations_list: List of dictionaries with 'operator' and 'columns' keys.
 
         Examples:
-        
+
         >>> data_frame = pd.DataFrame({"ID": [0, 1, 2], "a": [3.3, 4.5, 1.2], "b": [3, 2, 4})
         >>> ca = ColumnAggregator()
         >>> ca.aggregate(
         ...     [
         ...         {
-        ...             "operator": "mean", 
+        ...             "operator": "mean",
         ...             "columns": ["a, "b"],
         ...             "rename": "mean_a_b",
         ...         },
@@ -42,7 +42,13 @@ class ColumnAggregator:
         """
         LOGGER.debug("Starting column aggregation.")
 
-        operations = {"mean": self._mean, "last": self._last, "count": self._count}
+        operations = {
+            "mean": self._mean,
+            "last": self._last,
+            "count": self._count,
+            "max": self._max,
+            "sum": self._sum,
+        }
 
         for aggregation in operations_list:
             _operation = aggregation["operator"]
@@ -59,6 +65,14 @@ class ColumnAggregator:
             operations[_operation](_columns, _rename)
 
         LOGGER.debug("Finished column aggregation.")
+
+    def _sum(self, columns, rename):
+        self.frame[rename] = np.sum(self.frame[columns], axis=1)
+        self.frame = self.frame.drop(columns, axis=1)
+
+    def _max(self, columns, rename):
+        self.frame[rename] = np.max(self.frame[columns], axis=1)
+        self.frame = self.frame.drop(columns, axis=1)
 
     def _mean(self, columns, rename):
         self.frame[rename] = np.mean(self.frame[columns], axis=1)

--- a/numom2b_preprocessing/aggregate_columns.py
+++ b/numom2b_preprocessing/aggregate_columns.py
@@ -31,7 +31,7 @@ class ColumnAggregator:
         >>> data_frame = pd.DataFrame({"ID": [0, 1, 2], "a": [3.3, 4.5, 1.2], "b": [3, 2, 4})
         >>> ca = ColumnAggregator()
         >>> ca.aggregate(
-        ...     [
+                [
         ...         {
         ...             "operator": "mean",
         ...             "columns": ["a, "b"],
@@ -46,6 +46,7 @@ class ColumnAggregator:
             "mean": self._mean,
             "last": self._last,
             "count": self._count,
+            "min": self._min,
             "max": self._max,
             "sum": self._sum,
         }
@@ -72,6 +73,10 @@ class ColumnAggregator:
 
     def _max(self, columns, rename):
         self.frame[rename] = np.max(self.frame[columns], axis=1)
+        self.frame = self.frame.drop(columns, axis=1)
+
+    def _min(self, columns, rename):
+        self.frame[rename] = np.min(self.frame[columns], axis=1)
         self.frame = self.frame.drop(columns, axis=1)
 
     def _mean(self, columns, rename):

--- a/numom2b_preprocessing/clean_variables.py
+++ b/numom2b_preprocessing/clean_variables.py
@@ -20,12 +20,13 @@ class VariableCleaner:
 
     def clean(self, operations_list):
         """
-        :param operations: List of dictionaries with 'operator', 'columns', and 'value' keys.
+        :param operations_list: List of dictionaries with 'operator', 'columns', and 'value' keys.
         """
         LOGGER.debug("Started variable cleaning.")
 
         operations = {
             "default_value": self._default_value,
+            "difference": self._difference,
             "multiply_constant": self._multiply_constant,
             "replace": self._replace,
         }
@@ -44,7 +45,35 @@ class VariableCleaner:
     def _default_value(self, columns, value):
         self.frame[columns] = self.frame[columns].fillna(value)
 
+    def _difference(self, columns, value):
+
+        if not isinstance(value, str):
+            # 'value' is numeric and we should be able to subtract the constant.
+            self.frame[columns] = self.frame[columns] - value
+        else:
+
+            if len(columns) > 1:
+                raise ValueError(
+                    '"operation": "difference" between two columns is ambiguous.'
+                )
+
+            try:
+                self.frame[columns[0]] = self.frame[columns[0]] - self.frame[value]
+            except TypeError:
+                try:
+                    self.frame[columns[0]] = self.frame[columns[0]].astype(float) - self.frame[value].astype(float)
+                except ValueError as _message:
+                    LOGGER.error(
+                        "Error: {0} in (columns: {1})".format(_message, columns)
+                    )
+                    raise RuntimeError(
+                        'Could not complete "difference" operation on "{0}". Try "default_value" or "replace" first.'.format(
+                            columns
+                        )
+                    )
+
     def _multiply_constant(self, columns, value):
+        # TODO(@hayesall): Generalize to allow multiplying by content of a column.
         try:
             # Default behavior: multiply.
             self.frame[columns] = self.frame[columns] * value
@@ -66,4 +95,7 @@ class VariableCleaner:
 
     def _replace(self, columns, value):
         # Replace a specific value with another value.
-        self.frame[columns] = self.frame[columns].replace(value[0], value[1])
+        if value[1] == "NaN":
+            self.frame[columns] = self.frame[columns].replace(value[0], np.nan)
+        else:
+            self.frame[columns] = self.frame[columns].replace(value[0], value[1])

--- a/numom2b_preprocessing/clean_variables.py
+++ b/numom2b_preprocessing/clean_variables.py
@@ -6,7 +6,6 @@ Clean individual variables.
 
 import logging
 import numpy as np
-import pandas as pd
 
 LOGGER = logging.getLogger(__name__)
 

--- a/numom2b_preprocessing/preprocess.py
+++ b/numom2b_preprocessing/preprocess.py
@@ -15,7 +15,6 @@ LOGGER = logging.getLogger(__name__)
 
 def run(config_parameters):
     """
-    :arg config_parameters:
     :return: pandas.core.frame.DataFrame
 
     Preprocess the data according to the configuration parameters.
@@ -74,8 +73,6 @@ def _log_columns(csv_path, string_of_columns):
 
 def _build_target_table(file_name, columns):
     """
-    :param file_name:
-    :param columns_to_drop:
     :return: pandas.core.frame.DataFrame
     """
 

--- a/numom2b_preprocessing/preprocess.py
+++ b/numom2b_preprocessing/preprocess.py
@@ -8,7 +8,6 @@ from .aggregate_columns import ColumnAggregator
 from .clean_variables import VariableCleaner
 from .row_filter import RowFilter
 import logging
-import numpy as np
 import pandas as pd
 
 LOGGER = logging.getLogger(__name__)

--- a/numom2b_preprocessing/row_filter.py
+++ b/numom2b_preprocessing/row_filter.py
@@ -6,7 +6,6 @@ Conditionally filter rows.
 
 import logging
 import numpy as np
-import pandas as pd
 
 LOGGER = logging.getLogger(__name__)
 

--- a/numom2b_preprocessing/row_filter.py
+++ b/numom2b_preprocessing/row_filter.py
@@ -50,7 +50,10 @@ class RowFilter:
             raise Exception(
                 "Cannot use 'drop_if_equal' with multiple columns: ", columns
             )
-        self.frame = self.frame.drop(np.flatnonzero(self.frame[columns] == value))
+        if value == "NaN":
+            self.frame = self.frame.dropna(subset=columns)
+        else:
+            self.frame = self.frame.drop(np.flatnonzero(self.frame[columns] == value))
 
     def _not_equal(self, columns, value):
         if len(columns) > 1:

--- a/numom2b_preprocessing/row_filter.py
+++ b/numom2b_preprocessing/row_filter.py
@@ -25,8 +25,6 @@ class RowFilter:
 
         LOGGER.debug("Starting row filtering.")
 
-        # TODO: Conditions for handling null values.
-
         operations = {
             "drop_if_equal": self._equal,
             "drop_if_not_equal": self._not_equal,
@@ -40,6 +38,7 @@ class RowFilter:
             _value = aggregation["value"]
 
             LOGGER.debug("{0},{1},{2}".format(_operation, str(_columns), _value))
+
             operations[_operation](_columns, _value)
 
         LOGGER.debug("Finished row filtering.")
@@ -52,25 +51,29 @@ class RowFilter:
         if value == "NaN":
             self.frame = self.frame.dropna(subset=columns)
         else:
-            self.frame = self.frame.drop(np.flatnonzero(self.frame[columns] == value))
+            _entries = np.flatnonzero(self.frame[columns] == value)
+            self.frame.drop(self.frame.index[_entries], inplace=True)
 
     def _not_equal(self, columns, value):
         if len(columns) > 1:
             raise Exception(
                 "Cannot use 'drop_if_not_equal' with multiple columns: ", columns
             )
-        self.frame = self.frame.drop(np.flatnonzero(self.frame[columns] != value))
+        _entries = np.flatnonzero(self.frame[columns] != value)
+        self.frame.drop(self.frame.index[_entries], inplace=True)
 
     def _greater_than(self, columns, value):
         if len(columns) > 1:
             raise Exception(
                 "Cannot use 'drop_if_greater' with multiple columns: ", columns
             )
-        self.frame = self.frame.drop(np.flatnonzero(self.frame[columns] > value))
+        _entries = np.flatnonzero(self.frame[columns] > value)
+        self.frame.drop(self.frame.index[_entries], inplace=True)
 
     def _less_than(self, columns, value):
         if len(columns) > 1:
             raise Exception(
                 "Cannot use 'drop_if_less_than' with multiple columns: ", columns
             )
-        self.frame = self.frame.drop(np.flatnonzero(self.frame[columns] < value))
+        _entries = np.flatnonzero(self.frame[columns] < value)
+        self.frame.drop(self.frame.index[_entries], inplace=True)

--- a/numom2b_preprocessing/unittests/README.rst
+++ b/numom2b_preprocessing/unittests/README.rst
@@ -1,0 +1,18 @@
+##################################
+numom2b_preprocessing Unit Testing
+##################################
+
+First-time setup:
+
+.. code-block:: bash
+
+    pip install -r numom2b_preprocessing/unittests/requirements.txt
+
+Unit tests and code coverage are handled through ``coverage`` and ``unittest``:
+
+.. code-block:: bash
+
+    coverage run numom2b_preprocessing/unittests/test.py
+    coverage html
+    open -a "Firefox" htmlcov/index.html
+

--- a/numom2b_preprocessing/unittests/cleaning_tests/test_difference.py
+++ b/numom2b_preprocessing/unittests/cleaning_tests/test_difference.py
@@ -1,0 +1,138 @@
+# Copyright © 2019 Alexander L. Hayes
+
+"""
+Test for the ``preprocess._aggregate_columns._difference`` module.
+"""
+
+from pandas import DataFrame
+from pandas.util.testing import assert_frame_equal
+import unittest
+
+# Tests for:
+from ...clean_variables import VariableCleaner
+
+
+class PreprocessConstantDifferenceTests(unittest.TestCase):
+    """
+    Tests for the ``preprocess._aggregate_columns._difference`` module. Assert final data frames match expectations.
+    """
+
+    @staticmethod
+    def test_clean_difference_ints_0():
+        """Test subtracting 0 from a column."""
+        _input = DataFrame({"A": [1, 2, 3]})
+        _expected = DataFrame({"A": [1, 2, 3]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": 0}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_difference_ints_1():
+        """Test subtracting 1 from a column."""
+        _input = DataFrame({"A": [1, 2, 3]})
+        _expected = DataFrame({"A": [0, 1, 2]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": 1}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_difference_floats_0():
+        """Test subtracting 0.0 from a column."""
+        _input = DataFrame({"A": [1.0, 2.0, 3.0]})
+        _expected = DataFrame({"A": [1.0, 2.0, 3.0]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": 0.0}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_difference_floats_negative_1():
+        """Test subtracting -1.0 from a column."""
+        _input = DataFrame({"A": [1.0, 2.0, 3.0]})
+        _expected = DataFrame({"A": [2.0, 3.0, 4.0]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": -1.0}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+
+class PreprocessVariableDifferenceTests(unittest.TestCase):
+    """
+    Tests for the ``preprocess._aggregate_columns._difference`` module with column subtraction.
+    """
+
+    @staticmethod
+    def test_clean_difference_int_column():
+        """Test subtracting the right column from the left."""
+        _input = DataFrame({"A": [1, 2, 3], "B": [2, 3, 4]})
+        _expected = DataFrame({"A": [-1, -1, -1], "B": [2, 3, 4]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": "B"}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_difference_right_string_column():
+        """Test subtracting the right column from the left. Right column has strings."""
+        _input = DataFrame({"A": [1, 2, 3], "B": ["2", "3", "4"]})
+        _expected = DataFrame({"A": [-1.0, -1.0, -1.0], "B": ["2", "3", "4"]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": "B"}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_difference_left_string_column():
+        """Test subtracting the right column from the left. Left column has strings."""
+        _input = DataFrame({"A": ["1", "2", "3"], "B": [2, 3, 4]})
+        _expected = DataFrame({"A": [-1.0, -1.0, -1.0], "B": [2, 3, 4]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": "B"}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_difference_both_string_column():
+        """Test subtracting the right column from the left. Both left and right have strings."""
+        _input = DataFrame({"A": ["1", "2", "3"], "B": ["2", "3", "4"]})
+        _expected = DataFrame({"A": [-1.0, -1.0, -1.0], "B": ["2", "3", "4"]})
+
+        _groupings = [{"operator": "difference", "columns": ["A"], "value": "B"}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    def test_clean_ambiguous_difference(self):
+        """Test that a ValueError is raised when subtracting multiple named columns."""
+        _input = DataFrame({"a": [1, 2], "b": [2, 3], "c": [3, 4]})
+        _groupings = [{"operator": "difference", "columns": ["a", "b"], "value": "c"}]
+
+        _vc = VariableCleaner(_input)
+        with self.assertRaises(ValueError):
+            _vc.clean(_groupings)
+
+    def test_clean_difference_cannot_convert(self):
+        """Test that a RuntimeError is raised when columns cannot be converted to floats."""
+        _input = DataFrame({"a": [1, "b"], "b": [1, "c"]})
+        _groupings = [{"operator": "difference", "columns": ["a"], "value": "b"}]
+
+        _vc = VariableCleaner(_input)
+        with self.assertRaises(RuntimeError):
+            _vc.clean(_groupings)

--- a/numom2b_preprocessing/unittests/cleaning_tests/test_replace.py
+++ b/numom2b_preprocessing/unittests/cleaning_tests/test_replace.py
@@ -1,0 +1,52 @@
+# Copyright © 2019 Alexander L. Hayes
+
+"""
+Test for the ``preprocess._aggregate_columns._replace`` module.
+"""
+
+from numpy import nan
+from pandas import DataFrame
+from pandas.util.testing import assert_frame_equal
+import unittest
+
+# Tests for:
+from ...clean_variables import VariableCleaner
+
+
+class CleanReplaceTests(unittest.TestCase):
+
+    @staticmethod
+    def test_clean_replace_string_values():
+        """Replace strings in a column."""
+        _input = DataFrame({"a": [0, 1, "b"]})
+        _expected = DataFrame({"a": [0, 1, 2]})
+
+        _groupings = [{"operator": "replace", "columns": ["a"], "value": ["b", 2]}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_replace_int_values():
+        """Replace an int in a column."""
+        _input = DataFrame({"a": [0, 1, "b"]})
+        _expected = DataFrame({"a": [2, 1, "b"]})
+
+        _groupings = [{"operator": "replace", "columns": ["a"], "value": [0, 2]}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)
+
+    @staticmethod
+    def test_clean_replace_nan_values():
+        """Replace NaN values in a column."""
+        _input = DataFrame({"a": [0.0, 1.0, "a"]})
+        _expected = DataFrame({"a": [0.0, 1.0, nan]})
+
+        _groupings = [{"operator": "replace", "columns": ["a"], "value": ["a", "NaN"]}]
+        _vc = VariableCleaner(_input)
+        _vc.clean(_groupings)
+
+        assert_frame_equal(_expected, _vc.frame)

--- a/numom2b_preprocessing/unittests/column_aggregate_tests/test_aggregate_max.py
+++ b/numom2b_preprocessing/unittests/column_aggregate_tests/test_aggregate_max.py
@@ -1,0 +1,70 @@
+# Copyright © 2019 Alexander L. Hayes
+
+"""
+Tests for the ``aggregate_columns._max`` module.
+"""
+
+# TODO(@hayesall): max with np.nan values
+# TODO(@hayesall): max of empty data frame
+# TODO(@hayesall): max with strings / objects
+
+from pandas import DataFrame
+from pandas.util.testing import assert_frame_equal
+import unittest
+
+# Tests for:
+from ...aggregate_columns import ColumnAggregator
+
+
+class PreprocessMaxTests(unittest.TestCase):
+    """
+    Tests for the ``aggregate_columns.ColumnAggregator._max`` module. Assert final data frames match expectations.
+    """
+
+    @staticmethod
+    def test_aggregate_max_1():
+        """Test taking the max of one column."""
+        _input_1 = DataFrame({"ID": [0, 1, 2, 3], "a": [4.0, 3.0, 2.0, 1.0], "b": [10.0, 9.0, 8.0, 7.0]})
+        _expected = DataFrame({"ID": [0, 1, 2, 3], "b": [10.0, 9.0, 8.0, 7.0], "max_a": [4.0, 3.0, 2.0, 1.0]})
+
+        _groupings = [{"operator": "max", "columns": ["a"], "rename": "max_a"}]
+        _ca = ColumnAggregator(_input_1)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_max_2():
+        """Test taking the max of two columns."""
+        _input_2 = DataFrame({"a": [0.0, 0.0, 0.0], "b": [1.0, 2.0, 3.0]})
+        _expected = DataFrame({"max_ab": [1.0, 2.0, 3.0]})
+
+        _groupings = [{"operator": "max", "columns": ["a", "b"], "rename": "max_ab"}]
+        _ca = ColumnAggregator(_input_2)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_max_3():
+        """Test taking the max of three columns."""
+        _input_3 = DataFrame({"ID": [0, 1, 2], "a": [0.0, 1.0, 2.0], "b": [1.0, 0.0, 2.0], "c": [2.0, 1.0, 0.0]})
+        _expected = DataFrame({"ID": [0, 1, 2], "MAX_ABC": [2.0, 1.0, 2.0]})
+
+        _groupings = [{"operator": "max", "columns": ["a", "b", "c"], "rename": "MAX_ABC"}]
+        _ca = ColumnAggregator(_input_3)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_max_different_types():
+        """Test taking the max of two columns with int/float types."""
+        _input_4 = DataFrame({"ID": [0, 1, 2], "a": [0, 1, 0], "b": [0.0, 3.0, -1.0]})
+        _expected = DataFrame({"ID": [0, 1, 2], "max_ab": [0.0, 3.0, 0.0]})
+
+        _groupings = [{"operator": "max", "columns": ["a", "b"], "rename": "max_ab"}]
+        _ca = ColumnAggregator(_input_4)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)

--- a/numom2b_preprocessing/unittests/column_aggregate_tests/test_aggregate_min.py
+++ b/numom2b_preprocessing/unittests/column_aggregate_tests/test_aggregate_min.py
@@ -1,0 +1,70 @@
+# Copyright © 2019 Alexander L. Hayes
+
+"""
+Tests for the ``aggregate_columns._min`` module.
+"""
+
+# TODO(@hayesall): min with np.nan values
+# TODO(@hayesall): min of empty data frame
+# TODO(@hayesall): min with strings / objects
+
+from pandas import DataFrame
+from pandas.util.testing import assert_frame_equal
+import unittest
+
+# Tests for:
+from ...aggregate_columns import ColumnAggregator
+
+
+class PreprocessMinTests(unittest.TestCase):
+    """
+    Tests for the ``aggregate_columns.ColumnAggregator._min`` module. Assert final data frames match expectations.
+    """
+
+    @staticmethod
+    def test_aggregate_min_1():
+        """Test taking the min of one column."""
+        _input_1 = DataFrame({"ID": [0, 1, 2, 3], "a": [4.0, 3.0, 2.0, 1.0], "b": [10.0, 9.0, 8.0, 7.0]})
+        _expected = DataFrame({"ID": [0, 1, 2, 3], "b": [10.0, 9.0, 8.0, 7.0], "min_a": [4.0, 3.0, 2.0, 1.0]})
+
+        _groupings = [{"operator": "min", "columns": ["a"], "rename": "min_a"}]
+        _ca = ColumnAggregator(_input_1)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_min_2():
+        """Test taking the min of two columns."""
+        _input_2 = DataFrame({"a": [0.0, 0.0, 0.0], "b": [1.0, 2.0, 3.0]})
+        _expected = DataFrame({"min_ab": [0.0, 0.0, 0.0]})
+
+        _groupings = [{"operator": "min", "columns": ["a", "b"], "rename": "min_ab"}]
+        _ca = ColumnAggregator(_input_2)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_min_3():
+        """Test taking the min of three columns."""
+        _input_3 = DataFrame({"ID": [0, 1, 2], "a": [0.0, 1.0, 2.0], "b": [1.0, 0.0, 2.0], "c": [2.0, 1.0, 0.0]})
+        _expected = DataFrame({"ID": [0, 1, 2], "MIN_ABC": [0.0, 0.0, 0.0]})
+
+        _groupings = [{"operator": "min", "columns": ["a", "b", "c"], "rename": "MIN_ABC"}]
+        _ca = ColumnAggregator(_input_3)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_min_different_types():
+        """Test taking the min of two columns with int/float types."""
+        _input_4 = DataFrame({"ID": [0, 1, 2], "a": [0, 1, 0], "b": [0.0, 3.0, -1.0]})
+        _expected = DataFrame({"ID": [0, 1, 2], "min_ab": [0.0, 1.0, -1.0]})
+
+        _groupings = [{"operator": "min", "columns": ["a", "b"], "rename": "min_ab"}]
+        _ca = ColumnAggregator(_input_4)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)

--- a/numom2b_preprocessing/unittests/column_aggregate_tests/test_aggregate_sum.py
+++ b/numom2b_preprocessing/unittests/column_aggregate_tests/test_aggregate_sum.py
@@ -1,0 +1,56 @@
+# Copyright © 2019 Alexander L. Hayes
+
+"""
+Tests for the ``aggregate_columns._sum`` module.
+"""
+
+# TODO(@hayesall): Sum with np.nan values.
+
+from pandas import DataFrame
+from pandas.util.testing import assert_frame_equal
+import unittest
+
+# Tests for:
+from ...aggregate_columns import ColumnAggregator
+
+
+class PreprocessSumTests(unittest.TestCase):
+    """
+    Tests for the ``aggregate_columns.ColumnAggregator._sum`` module. Assert final data match expectations.
+    """
+
+    @staticmethod
+    def test_aggregate_sum_1():
+        """Test taking the sum of one column."""
+        _input_1 = DataFrame({"a": [0, 0, 0]})
+        _expected = DataFrame({"sum_a": [0, 0, 0]})
+
+        _groupings = [{"operator": "sum", "columns": ["a"], "rename": "sum_a"}]
+        _ca = ColumnAggregator(_input_1)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_sum_2():
+        """Test taking the sum of two columns."""
+        _input_2 = DataFrame({"a": [0, 1, 2], "b": [2, 1, 0]})
+        _expected = DataFrame({"sum_ab": [2, 2, 2]})
+
+        _groupings = [{"operator": "sum", "columns": ["a", "b"], "rename": "sum_ab"}]
+        _ca = ColumnAggregator(_input_2)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)
+
+    @staticmethod
+    def test_aggregate_sum_3():
+        """Test taking the sum of three columns."""
+        _input_3 = DataFrame({"A": [3.0, 1.0], "B": [4.0, 0.0], "C": [4.5, 5.5]})
+        _expected = DataFrame({"Sum_ABC": [11.5, 6.5]})
+
+        _groupings = [{"operator": "sum", "columns": ["A", "B", "C"], "rename": "Sum_ABC"}]
+        _ca = ColumnAggregator(_input_3)
+        _ca.aggregate(_groupings)
+
+        assert_frame_equal(_expected, _ca.frame)

--- a/numom2b_preprocessing/unittests/row_filter_tests/test_drop_if_nan.py
+++ b/numom2b_preprocessing/unittests/row_filter_tests/test_drop_if_nan.py
@@ -1,0 +1,82 @@
+# Copyright © 2019 Alexander L. Hayes
+
+"""
+Tests for the variable/column with cleaning with ``RowFilter._equal(columns, "NaN")``
+"""
+
+from numpy import nan
+from pandas import DataFrame
+from pandas.util.testing import assert_frame_equal
+import unittest
+
+# Tests for:
+from ...row_filter import RowFilter
+
+
+class CleanDropIfNaNTests(unittest.TestCase):
+    """
+    Tests for the ``preprocess._clean_variables`` module dropping rows based on ``== "NaN"``
+    """
+
+    @staticmethod
+    def test_drop_if_equal_nan_1():
+        """Test that nothing is dropped"""
+        _table_1 = DataFrame({"a": [1.0, 2.0, 3.0], "b": [2.0, 3.0, 4.0]})
+
+        _cleanings = [
+            {"operator": "drop_if_equal", "columns": ["a"], "value": "NaN"},
+            {"operator": "drop_if_equal", "columns": ["b"], "value": "NaN"},
+        ]
+        _rf = RowFilter(_table_1)
+        _rf.filter(_cleanings)
+
+        assert_frame_equal(_table_1, _rf.frame)
+
+    @staticmethod
+    def test_drop_if_equal_nan_2():
+        """Test that a single row is dropped"""
+        _table_2 = DataFrame({"a": [1.0, nan, 3.0], "b": [2.0, 3.0, 4.0]})
+
+        _cleanings = [{"operator": "drop_if_equal", "columns": ["a"], "value": "NaN"}]
+        _expected = DataFrame({"a": [1.0, 3.0], "b": [2.0, 4.0]})
+
+        _rf = RowFilter(_table_2)
+        _rf.filter(_cleanings)
+
+        # TODO(@hayesall): This is a hack for indexes
+        _expected.index = _rf.frame.index
+
+        assert_frame_equal(_expected, _rf.frame)
+
+    @staticmethod
+    def test_drop_if_equal_nan_3():
+        """Test that everything is dropped."""
+        _table_3 = DataFrame({"a": [nan, nan, nan], "b": [1.0, 2.0, 3.0]})
+
+        _cleanings = [{"operator": "drop_if_equal", "columns": ["a"], "value": "NaN"}]
+        _expected = DataFrame({"a": [], "b": []})
+
+        _rf = RowFilter(_table_3)
+        _rf.filter(_cleanings)
+
+        assert_frame_equal(_expected, _rf.frame)
+
+    def test_drop_if_equal_nan_4(self):
+        """Test that an error is raised when multiple columns are passed."""
+        _table_4 = DataFrame({"a": [1.0, 2.0, 3.0], "b": [2.0, 3.0, 4.0]})
+        _cleanings = [{"operator": "drop_if_equal", "columns": ["a", "b"], "value": "NaN"}]
+
+        with self.assertRaises(Exception):
+            _rf = RowFilter(_table_4)
+            _rf.filter(_cleanings)
+
+    @staticmethod
+    def test_drop_if_equal_nan_5():
+        """Test that nothing is dropped when the condition is passed in another row."""
+        _table_5 = DataFrame({"a": [nan, nan, nan], "b": [1.0, 2.0, 3.0]})
+        _cleanings = [{"operator": "drop_if_equal", "columns": ["b"], "value": "NaN"}]
+
+        _rf = RowFilter(_table_5)
+        _rf.filter(_cleanings)
+
+        assert_frame_equal(_table_5, _rf.frame)

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
-# Copyright 2019 Alexander L. Hayes
+# Copyright © 2019 Alexander L. Hayes
 
 from setuptools import setup
 from setuptools import find_packages
+from os import path
 
-from numom2b_preprocessing._meta import __version__
+# Get __version__ from _meta.py
+with open(path.join("numom2b_preprocessing", "_meta.py")) as f:
+    exec(f.read())
 
 setup(
     name="numom2b_preprocessing",
@@ -17,4 +20,5 @@ setup(
     entry_points={
         "console_scripts": ["numom2b_preprocessing=numom2b_preprocessing.__main__"]
     },
+    install_requires=['numpy', 'pandas']
 )


### PR DESCRIPTION
Aggregation Operations:

- `min`: minimum of row values between columns
- `max`: maximum of row values between columns
- `sum`: sum of row values between columns

Cleaning Operations:

- `difference`: Difference between column & constant, or column & column
- `multiply_constant`: Support for column type conversion
- `replace`: Replace specific values or set a value to NaN in a column

Row Filtering Operations:

- `drop_if_not_equal`, `drop_if_equal`, etc. are now more robust to missing values. This makes it easier to chain multiple conditional drops at the end.

Other changes:

- Add LGTM analysis
- Bump version to `0.2.1`
- Fix a potential issue in `setup.py` where importing `numom2b_preprocessing._meta` would occasionally fail, causing the setup process to fail.
- Fix documentation references to `groupings` by replacing them with `aggregate_columns`, the correct keyword going forward (`groupings` is pending removal in 0.3.0 release).